### PR TITLE
add (currently failing) map vs loop test

### DIFF
--- a/samples-loose-types/tests/map_vs_loop.rs
+++ b/samples-loose-types/tests/map_vs_loop.rs
@@ -1,0 +1,38 @@
+#![feature(autodiff)]
+
+#[autodiff(sin_vec, Reverse, Duplicated, Active)]
+fn cos_vec(x: &Vec<f32>) -> f32 {
+
+    let theta_inverse = 1.0 / x.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+    let mut w = [0.; 3];
+    for i in 0..3 {
+        w[i] = x[i] * theta_inverse;
+    }
+    w.iter().sum()
+}
+
+#[autodiff(sin_vec2, Reverse, Duplicated, Active)]
+fn cos_vec2(x: &Vec<f32>) -> f32 {
+
+    let theta_inverse = 1.0 / x.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+    let w = x.iter().map(|v| v * theta_inverse);
+    w.sum()
+}
+
+#[test]
+fn compare() {
+    let x = vec![1.0, 2.0, 3.0];
+    let x2 = vec![1.0, 2.0, 3.0];
+    let mut d_x = vec![0.0; 3];
+    let mut d_x2 = vec![0.0; 3];
+
+    sin_vec(&x, &mut d_x, 1.0);
+    sin_vec2(&x, &mut d_x, 1.0);
+
+    dbg!(&d_x, &x);
+    dbg!(&d_x2, &x2);
+
+    for i in 0..3 {
+        assert!((d_x[i] - d_x2[i]).abs() < 1e-6);
+    }
+}

--- a/samples-loose-types/tests/mod.rs
+++ b/samples-loose-types/tests/mod.rs
@@ -1,3 +1,5 @@
 #![feature(autodiff)]
 
 mod neohookean;
+mod map_vs_loop;
+


### PR DESCRIPTION
Our challenge of the day @wsmoses

```
running 1 test
test compare ... FAILED

failures:

---- compare stdout ----
[samples-loose-types/tests/map_vs_loop.rs:32:5] &d_x = [
    0.30544144,
    0.07636039,
    -0.15272069,
]
[samples-loose-types/tests/map_vs_loop.rs:32:5] &x = [
    1.0,
    2.0,
    3.0,
]
[samples-loose-types/tests/map_vs_loop.rs:33:5] &d_x2 = [
    0.0,
    0.0,
    0.0,
]
[samples-loose-types/tests/map_vs_loop.rs:33:5] &x2 = [
    1.0,
    2.0,
    3.0,
]
thread 'compare' panicked at samples-loose-types/tests/map_vs_loop.rs:36:9:
assertion failed: (d_x[i] - d_x2[i]).abs() < 1e-6

```