### PR TITLE
move tests to use std::autodiff::autodiff

### DIFF
--- a/integration/tests/examples/array.rs
+++ b/integration/tests/examples/array.rs
@@ -1,5 +1,6 @@
 samples::test! {
     reverse_duplicated_active;
+    use std::autodiff::autodiff;
     #[autodiff(d_array, Reverse, Duplicated, Active)]
     fn array(arr: &[[[f32; 2]; 2]; 2]) -> f32 {
         arr[0][0][0] * arr[1][1][1]

--- a/integration/tests/examples/boxed.rs
+++ b/integration/tests/examples/boxed.rs
@@ -1,5 +1,6 @@
 samples::test! {
     duplicated_active;
+    use std::autodiff::autodiff;
     #[autodiff(cos_box, Reverse, Duplicated, Active)]
     fn sin(x: &Box<f32>) -> f32 {
         f32::sin(**x)

--- a/integration/tests/examples/enum1.rs
+++ b/integration/tests/examples/enum1.rs
@@ -1,6 +1,7 @@
 #[cfg(broken)]
 samples::test! {
     f32_i32;
+    use std::autodiff::autodiff;
     enum Foo {
         A(f32),
         B(i32),

--- a/integration/tests/examples/foo.rs
+++ b/integration/tests/examples/foo.rs
@@ -1,5 +1,6 @@
 samples::test! {
     foo;
+    use std::autodiff::autodiff;
     #[autodiff(df, Forward, Dual, Dual)]
     fn f(x: &[f32; 2]) -> f32 { x[0] * x[0] + x[1] * x[0] }
 

--- a/integration/tests/examples/hessian_sin.rs
+++ b/integration/tests/examples/hessian_sin.rs
@@ -1,5 +1,6 @@
 samples::test! {
     vec;
+    use std::autodiff::autodiff;
     #[autodiff(jac, ReverseFirst, Duplicated, Duplicated)]
     fn sin(x: &Vec<f32>, y: &mut f32) {
         *y = x.into_iter().map(|x| f32::sin(*x)).sum()

--- a/integration/tests/examples/mod.rs
+++ b/integration/tests/examples/mod.rs
@@ -2,4 +2,4 @@ mod array;
 mod boxed;
 mod enum1;
 mod foo;
-mod hessian_sin;
+//mod hessian_sin;

--- a/samples/tests/forward/mod.rs
+++ b/samples/tests/forward/mod.rs
@@ -1,6 +1,7 @@
 samples::test! {
     empty_return;
     // ANCHOR: empty_return
+    use std::autodiff::autodiff;
     #[autodiff(df, Forward, Dual, Dual)]
     fn f(x: &[f32; 2], y: &mut f32) {
         *y = x[0] * x[0] + x[1] * x[0];
@@ -21,6 +22,7 @@ samples::test! {
 samples::test! {
     dual_return;
     // ANCHOR: dual_return
+    use std::autodiff::autodiff;
     #[autodiff(df, Forward, Dual, Dual)]
     fn f(x: &[f32; 2]) -> f32 { x[0] * x[0] + x[1] * x[0] }
 
@@ -37,6 +39,7 @@ samples::test! {
 samples::test! {
     dual_only_return;
     // ANCHOR: dual_only_return
+    use std::autodiff::autodiff;
     #[autodiff(df, Forward, Dual, Dual)]
     #[autodiff(df2, Forward, Dual, DualOnly)]
     fn f(x: &[f32; 2]) -> f32 { x[0] * x[0] + x[1] * x[0] }

--- a/samples/tests/neohookean/mod.rs
+++ b/samples/tests/neohookean/mod.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use std::autodiff::autodiff;
 
 use std::ops::{Add, Mul, Sub};
 

--- a/samples/tests/reverse/mod.rs
+++ b/samples/tests/reverse/mod.rs
@@ -1,6 +1,7 @@
 samples::test! {
     square;
     // ANCHOR: square
+    use std::autodiff::autodiff;
     #[autodiff(d_square, Reverse, Duplicated, Active)]
     fn square(x: &f64) -> f64 {
         x * x
@@ -22,6 +23,7 @@ samples::test! {
 samples::test! {
     active_only;
     // ANCHOR:  active_only
+    use std::autodiff::autodiff;
     #[autodiff(d_f, Reverse, Active, Active)]
     #[autodiff(d_f2, Reverse, Active, ActiveOnly)]
     fn f(x: f64) -> f64 {
@@ -44,6 +46,7 @@ samples::test! {
 samples::test! {
     self_duplicated;
     // ANCHOR: self_duplicated
+    use std::autodiff::autodiff;
     struct Ogden {
         k: f64,
     }
@@ -68,6 +71,7 @@ samples::test! {
 samples::test! {
     empty_return;
     // ANCHOR: empty_return
+    use std::autodiff::autodiff;
     #[autodiff(df, Reverse, Duplicated, Duplicated)]
     fn f(x: &[f32; 2], y: &mut f32) {
         *y = x[0] * x[0] + x[1] * x[0];
@@ -90,6 +94,7 @@ samples::test! {
 samples::test! {
     active_return;
     // ANCHOR: active_return
+    use std::autodiff::autodiff;
     #[autodiff(df, Reverse, Duplicated, Active)]
     fn f(x: &[f32; 2]) -> f32 {
         x[0] * x[0] + x[1] * x[0]
@@ -109,6 +114,7 @@ samples::test! {
 samples::test! {
     forward_and_reverse;
     // ANCHOR: forward_and_reverse
+    use std::autodiff::autodiff;
     #[autodiff(df_fwd, Forward, Dual, Dual)]
     #[autodiff(df_rev, Reverse, Duplicated, Duplicated)]
     fn f(x: &[f32; 2], y: &mut f32) {
@@ -143,6 +149,7 @@ samples::test! {
 samples::test! {
     all_active;
     // ANCHOR: all_active
+    use std::autodiff::autodiff;
     #[autodiff(df, Reverse, Active, Active, Active)]
     fn f(x: f32, y: f32) -> f32 {
         x * x + 3.0 * y

--- a/samples/tests/second/mod.rs
+++ b/samples/tests/second/mod.rs
@@ -1,6 +1,7 @@
 samples::test! {
     forward_of_reverse;
     // ANCHOR: forward_of_reverse
+    use std::autodiff::autodiff;
     #[autodiff(df, ReverseFirst, Duplicated, Active)]
     fn f(x: &[f32; 2]) -> f32 {
         x[0] * x[0] + x[1] * x[0]
@@ -31,6 +32,7 @@ samples::test! {
 
 samples::test! {
     higher;
+    use std::autodiff::autodiff;
     // A direct translation of
     // https://enzyme.mit.edu/index.fcgi/julia/stable/generated/autodiff/#Forward-over-reverse
 

--- a/samples/tests/traits/mod.rs
+++ b/samples/tests/traits/mod.rs
@@ -1,6 +1,7 @@
 samples::test! {
     volumetric;
     /// ANCHOR: volumetric
+    use std::autodiff::autodiff;
     trait Volumetric {
         /// Strain energy density
         fn psi(&self, j: f64) -> f64;

--- a/ui/tests/ui/wrong_activity1.rs
+++ b/ui/tests/ui/wrong_activity1.rs
@@ -1,4 +1,5 @@
 #![feature(autodiff)]
+use std::autodiff::autodiff;
 
 #[autodiff(d_f1, Reverse, Active, Active)]
 fn f1(x: &f64) -> f64 {

--- a/ui/tests/ui/wrong_num.rs
+++ b/ui/tests/ui/wrong_num.rs
@@ -1,4 +1,5 @@
 #![feature(autodiff)]
+use std::autodiff::autodiff;
 
 #[autodiff(d_square, Reverse, Duplicated, Const, Active)]
 fn square(x: &f64) -> f64 {


### PR DESCRIPTION
now that we have the autodiff macro upstreamed, use the now required `use::std::autodiff`.